### PR TITLE
Fix119

### DIFF
--- a/py5_resources/py5_module/py5/vector.py
+++ b/py5_resources/py5_module/py5/vector.py
@@ -36,6 +36,7 @@ class Py5Vector(Sequence):
         kwarg_dim = dim
         kwarg_dtype = dtype
 
+        used_default_dim = len(args) == 0 and dim is None
         dim = 3 if dim is None else dim
         dtype = np.float_ if dtype is None else dtype
 
@@ -108,6 +109,7 @@ class Py5Vector(Sequence):
             raise RuntimeError(f'Why is dim == {dim}? Please report bug')
 
         v._data = data
+        v._used_default_dim = used_default_dim
 
         return v
 

--- a/py5_resources/py5_module/py5/vector.py
+++ b/py5_resources/py5_module/py5/vector.py
@@ -31,13 +31,14 @@ import numpy.typing as npt
 class Py5Vector(Sequence):
     """$classdoc_Py5Vector
     """
+    _DEFAULT_DIM = 3
 
     def __new__(cls, *args, dim: int = None, dtype: type = None, copy: bool = True):
         kwarg_dim = dim
         kwarg_dtype = dtype
 
         used_default_dim = len(args) == 0 and dim is None
-        dim = 3 if dim is None else dim
+        dim = Py5Vector._DEFAULT_DIM if dim is None else dim
         dtype = np.float_ if dtype is None else dtype
 
         if not isinstance(dtype, (type, np.dtype)) or not np.issubdtype(dtype, np.floating):
@@ -152,12 +153,19 @@ class Py5Vector(Sequence):
     def __repr__(self):
         return f'Py5Vector{self._data.size}D{repr(self._data)[5:]}'
 
+    def _check_used_default_dim(self, other):
+        if self._used_default_dim or (isinstance(other, Py5Vector) and other._used_default_dim):
+            other_dim = self._data.size + other._data.size - Py5Vector._DEFAULT_DIM
+            return f" Note that one of the Py5Vectors was created with Py5Vector(), and is therefore by default a {Py5Vector._DEFAULT_DIM}D vector. If you wanted a {other_dim}D vector instead, use the `dim` parameter, like this: Py5Vector(dim={other_dim})."
+        else:
+            return ""
+
     def _run_op(self, op, other, opname, swap=False, inplace=False, allow2vectors=False):
         if isinstance(other, Py5Vector):
             if not allow2vectors:
                 raise RuntimeError(f"Cannot perform {opname} operation on two Py5Vectors. If you want to do {opname} on the Py5Vector's data elementwise, use the `.data` attribute to access the Py5Vector's data as a numpy array.")
             elif self._data.size != other._data.size:
-                raise RuntimeError(f"Cannot perform {opname} operation on a {self._data.size}D Py5Vector a {other._data.size}D Py5Vector. The dimensions must be the same.")
+                raise RuntimeError(f"Cannot perform {opname} operation on a {self._data.size}D Py5Vector and a {other._data.size}D Py5Vector. The dimensions must be the same." + self._check_used_default_dim(other))
             elif inplace:
                 op(self._data[:other._data.size], other._data[:other._data.size])
                 return self
@@ -338,7 +346,7 @@ class Py5Vector(Sequence):
             if self._data.size == other._data.size:
                 other = other._data
             else:
-                raise RuntimeError(f'Py5Vector dimensions must be the same to calculate the {name} two Py5Vectors')
+                raise RuntimeError(f'Py5Vector dimensions must be the same to calculate the {name} two Py5Vectors.' + self._check_used_default_dim(other))
 
         if isinstance(other, np.ndarray):
             try:


### PR DESCRIPTION
Now you'll see an error message like this when the default size of 3 is used:

```txt
RuntimeError: Cannot perform addition operation on a 3D Py5Vector and a 2D Py5Vector. The dimensions must be the same. Note that one of the Py5Vectors was created with Py5Vector(), and is therefore by default a 3D vector. If you wanted a 2D vector instead, use the `dim` parameter, like this: Py5Vector(dim=2).
```

It will suggest `dim=4` if the other vector is 4D.