### PR TITLE
Adding `exit_sketch()` information, and other tweaks.

### DIFF
--- a/py5_docs/Reference/api_en/Sketch_size.txt
+++ b/py5_docs/Reference/api_en/Sketch_size.txt
@@ -40,6 +40,8 @@ The ``renderer`` parameter selects which rendering engine to use. For example, i
 * ``PDF``: The ``PDF`` renderer draws 2D graphics directly to an Acrobat PDF file. This produces excellent results when you need vector shapes for high-resolution output or printing.
 * ``SVG``: The ``SVG`` renderer draws 2D graphics directly to an SVG file. This is great for importing into other vector programs or using for digital fabrication.
 
+When using the ``PDF`` and ``SVG`` rendererers that write to a file, you must call ``exit_sketch()`` by the end of your drawing. If you'd like to draw 3D objects to a PDF or SVG file, you might try the ``begin_raw()`` method istead of this.
+
 @@ example
 def setup():
     py5.size(200, 100)
@@ -70,3 +72,10 @@ def setup():
     py5.rotate_x(py5.PI/6)
     py5.rotate_y(py5.PI/6)
     py5.box(35)
+
+@@ example
+def setup():
+    py5.size(200, 400, py5.PDF, 'output.pdf')
+    py5.background(153)
+    py5.line(0, 0, py5.width, py5.height)
+    py5.exit_sketch()  # needed to save and close the output properly 

--- a/py5_docs/Reference/api_en/Sketch_size.txt
+++ b/py5_docs/Reference/api_en/Sketch_size.txt
@@ -40,7 +40,7 @@ The ``renderer`` parameter selects which rendering engine to use. For example, i
 * ``PDF``: The ``PDF`` renderer draws 2D graphics directly to an Acrobat PDF file. This produces excellent results when you need vector shapes for high-resolution output or printing.
 * ``SVG``: The ``SVG`` renderer draws 2D graphics directly to an SVG file. This is great for importing into other vector programs or using for digital fabrication.
 
-When using the ``PDF`` and ``SVG`` rendererers that write to a file, you must call ``exit_sketch()`` by the end of your drawing. If you'd like to draw 3D objects to a PDF or SVG file, you might try the ``begin_raw()`` method istead of this.
+When using the ``PDF`` and ``SVG`` renderers with the ``size()`` method, you must use the ``path`` parameter to specify the file to write the output to. No window will open while the Sketch is running. You must also call :doc:`sketch_exit_sketch` to exit the Sketch and write the completed output to the file. Without this call, the Sketch will not exit and the output file will be empty. If you would like to draw 3D objects to a PDF or SVG file, use the ``P3D`` renderer and the strategy described in :doc:`sketch_begin_raw`.
 
 @@ example
 def setup():


### PR DESCRIPTION
Adding the need for `exit_sketch()` as discussed in https://github.com/py5coding/py5generator/issues/137
Also mentioned you might try `begin_raw()` if you want 3D, and an example.

Please proof read and make any edit you see fit!