### PR TITLE
breaking signature of some methods  in many lines

### DIFF
--- a/py5_docs/Reference/api_en/Py5Tools_animated_gif.txt
+++ b/py5_docs/Reference/api_en/Py5Tools_animated_gif.txt
@@ -5,7 +5,17 @@ category = sketch_hooks
 subcategory = None
 
 @@ signatures
-animated_gif(filename: str, count: int, period: float, duration: float, *, loop: int = 0, optimize: bool = True, sketch: Sketch = None, hook_post_draw: bool = False, block: bool = False) -> None
+animated_gif(
+    filename: str,
+    count: int,
+    period: float,
+    duration: float, *, 
+    loop: int = 0,
+    optimize: bool = True,
+    sketch: Sketch = None,
+    hook_post_draw: bool = False,
+    block: bool = False
+    ) -> None
 
 @@ variables
 block: bool = False - method returns immediately (False) or blocks until function returns (True)

--- a/py5_docs/Reference/api_en/Py5Tools_offline_frame_processing.txt
+++ b/py5_docs/Reference/api_en/Py5Tools_offline_frame_processing.txt
@@ -5,7 +5,18 @@ category = sketch_hooks
 subcategory = None
 
 @@ signatures
-offline_frame_processing(func: Callable[[npt.NDArray[np.uint8]], None], *, limit: int = 0, period: float = 0.0, batch_size: int = 1, complete_func: Callable[[], None] = None, stop_processing_func: Callable[[], bool] = None, sketch: Sketch = None, hook_post_draw: bool = False, queue_limit: int = None, block: bool = False) -> None
+offline_frame_processing(
+    func: Callable[[npt.NDArray[np.uint8]], None], *,
+    limit: int = 0,
+    period: float = 0.0,
+    batch_size: int = 1,
+    complete_func: Callable[[], None] = None,
+    stop_processing_func: Callable[[], bool] = None,
+    sketch: Sketch = None,
+    hook_post_draw: bool = False,
+    queue_limit: int = None,
+    block: bool = False
+    ) -> None
 
 @@ variables
 batch_size: int = 1 - number of frames to include in each batch passed to the frame processing function


### PR DESCRIPTION
exploratory PR for https://github.com/py5coding/py5generator/issues/102 ... would this work?

Just to confirm, the `*` by convention marks the start of the keyword/optional arguments?