### PR TITLE
Check for headless JVM and non-graphical environment

### DIFF
--- a/py5_jar/src/main/java/py5/util/CheckHeadless.java
+++ b/py5_jar/src/main/java/py5/util/CheckHeadless.java
@@ -1,0 +1,40 @@
+/******************************************************************************
+
+  Part of the py5 library
+  Copyright (C) 2020-2023 Jim Schmitz
+
+  This library is free software: you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 2.1 of the License, or (at
+  your option) any later version.
+
+  This library is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+******************************************************************************/
+package py5.util;
+
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+
+public class CheckHeadless {
+
+  public static boolean test() {
+    if (GraphicsEnvironment.isHeadless()) {
+      return true;
+    }
+
+    try {
+      GraphicsDevice[] devices = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
+      return devices == null || devices.length == 0;
+    } catch (Exception e) {
+      return true;
+    }
+  }
+
+}

--- a/py5_jar/src/main/java/py5/util/KeyEventUtilities.java
+++ b/py5_jar/src/main/java/py5/util/KeyEventUtilities.java
@@ -1,3 +1,22 @@
+/******************************************************************************
+
+  Part of the py5 library
+  Copyright (C) 2020-2023 Jim Schmitz
+
+  This library is free software: you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 2.1 of the License, or (at
+  your option) any later version.
+
+  This library is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+******************************************************************************/
 package py5.util;
 
 import java.awt.Component;

--- a/py5_resources/py5_module/py5/__init__.py
+++ b/py5_resources/py5_module/py5/__init__.py
@@ -75,6 +75,11 @@ if not py5_tools.is_jvm_running():
         print(debug_info, file=sys.stderr)
         raise RuntimeError("py5 is unable to start Java 17 Virtual Machine")
 
+    if JClass("py5.util.CheckHeadless")().test():
+        raise RuntimeError(
+            "py5 is unable to run correctly in headless mode. Make sure you are running in a graphical environment and that your Java Virtual Machine is not a Headless JVM."
+        )
+
 import py5_tools.colors.css4 as css4_colors  # noqa
 import py5_tools.colors.mpl_cmaps as mpl_cmaps  # noqa
 import py5_tools.colors.xkcd as xkcd_colors  # noqa


### PR DESCRIPTION
For #346 

Now you will get this error if you have a headless JVM

```
>>> import py5
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jim/INSTALL/anaconda3/envs/py5/lib/python3.8/site-packages/py5/__init__.py", line 78, in <module>
    raise RuntimeError(
RuntimeError: py5 is unable to run correctly in headless mode. Make sure you are running in a graphical environment and that your Java Virtual Machine is not a Headless JVM.
```