### PR TITLE
Improve py5_tools.screenshot()

### DIFF
--- a/py5_docs/Reference/api_en/Py5Tools_screenshot.txt
+++ b/py5_docs/Reference/api_en/Py5Tools_screenshot.txt
@@ -18,7 +18,9 @@ The returned image is a `PIL.Image` object. It can be assigned to a variable or 
 
 By default the Sketch will be the currently running Sketch, as returned by [](py5functions_get_current_sketch). Use the `sketch` parameter to specify a different running Sketch, such as a Sketch created using Class mode.
 
-This function only works on a Sketch with a `draw()` function. If your Sketch has a `post_draw()` method, use the `hook_post_draw` parameter to make this function run after `post_draw()` instead of `draw()`. This is important when using Processing libraries that support `post_draw()` such as Camera3D or ColorBlindness.
+This function will not work on a Sketch with no `draw()` function that uses an OpenGL renderer such as `P2D` or `P3D`. Either add a token `draw()` function or switch to the default `JAVA2D` renderer.
+
+If your Sketch has a `post_draw()` method, use the `hook_post_draw` parameter to make this function run after `post_draw()` instead of `draw()`. This is important when using Processing libraries that support `post_draw()` such as Camera3D or ColorBlindness.
 
 @@ example
 import time

--- a/py5_resources/py5_module/py5_tools/hooks/frame_hooks.py
+++ b/py5_resources/py5_module/py5_tools/hooks/frame_hooks.py
@@ -28,6 +28,7 @@ from typing import Callable, Iterable
 import numpy as np
 import numpy.typing as npt
 import PIL
+from jpype import JClass
 from PIL.Image import Image as PIL_Image
 
 from .. import environ as _environ
@@ -75,8 +76,14 @@ def screenshot(*, sketch: Sketch = None, hook_post_draw: bool = False) -> PIL_Im
             elif hook.is_terminated and hook.exception:
                 raise RuntimeError("error running magic: " + str(hook.exception))
     else:
-        sketch.load_np_pixels()
-        return PIL.Image.fromarray(sketch.np_pixels[:, :, 1:], mode="RGB")
+        if isinstance(
+            sketch.get_graphics()._instance, JClass("processing.opengl.PGraphicsOpenGL")
+        ):
+            msg = "The py5_tools.screenshot() function cannot be used on an OpenGL Sketch with no draw() function."
+            raise RuntimeError(msg)
+        else:
+            sketch.load_np_pixels()
+            return PIL.Image.fromarray(sketch.np_pixels[:, :, 1:], mode="RGB")
 
 
 def save_frames(

--- a/py5_resources/py5_module/py5_tools/hooks/frame_hooks.py
+++ b/py5_resources/py5_module/py5_tools/hooks/frame_hooks.py
@@ -62,18 +62,15 @@ def screenshot(*, sketch: Sketch = None, hook_post_draw: bool = False) -> PIL_Im
         msg = "Calling py5_tools.screenshot() from within a py5 user function is not allowed. Please move this code to outside the Sketch or consider using save_frame() instead."
         raise RuntimeError(msg)
 
-    with tempfile.TemporaryDirectory() as tempdir:
-        temp_png = Path(tempdir) / "output.png"
-        hook = ScreenshotHook(temp_png)
-        sketch._add_post_hook(
-            "post_draw" if hook_post_draw else "draw", hook.hook_name, hook
-        )
+    hook = ScreenshotHook()
+    sketch._add_post_hook(
+        "post_draw" if hook_post_draw else "draw", hook.hook_name, hook
+    )
 
-        while not hook.is_ready and not hook.is_terminated:
-            time.sleep(0.005)
-
+    while not hook.is_ready and not hook.is_terminated:
+        time.sleep(0.005)
         if hook.is_ready:
-            return PIL.Image.open(temp_png)
+            return PIL.Image.fromarray(hook.pixels, mode="RGB")
         elif hook.is_terminated and hook.exception:
             raise RuntimeError("error running magic: " + str(hook.exception))
 

--- a/py5_resources/py5_module/py5_tools/hooks/hooks.py
+++ b/py5_resources/py5_module/py5_tools/hooks/hooks.py
@@ -72,13 +72,14 @@ class BaseHook:
 
 
 class ScreenshotHook(BaseHook):
-    def __init__(self, filename):
+    def __init__(self):
         super().__init__("py5screenshot_hook")
-        self.filename = filename
+        self.pixels = []
 
     def __call__(self, sketch):
         try:
-            sketch.save_frame(self.filename, use_thread=False)
+            sketch.load_np_pixels()
+            self.pixels = sketch.np_pixels[:, :, 1:].copy()
             self.hook_finished(sketch)
         except Exception as e:
             self.hook_error(sketch, e)


### PR DESCRIPTION
Now `py5_tools.screenshot()` will work on Sketches with no `draw()` function that use the default renderer.