### PR TITLE
Bugfix/no ref/correct constrain documentation

### DIFF
--- a/py5_docs/Reference/api_en/Sketch_constrain.txt
+++ b/py5_docs/Reference/api_en/Sketch_constrain.txt
@@ -13,7 +13,7 @@ high: Union[float, npt.NDArray] - maximum limit
 low: Union[float, npt.NDArray] - minimum limit
 
 @@ description
-Constrains a value to not exceed a maximum and minimum value.
+Constrains a value between a minimum and maximum value.
 
 @@ example
 def draw():

--- a/py5_docs/Reference/api_en/Sketch_constrain.txt
+++ b/py5_docs/Reference/api_en/Sketch_constrain.txt
@@ -9,8 +9,8 @@ constrain(amt: Union[float, npt.NDArray], low: Union[float, npt.NDArray], high: 
 
 @@ variables
 amt: Union[float, npt.NDArray] - the value to constrain
-high: Union[float, npt.NDArray] - minimum limit
-low: Union[float, npt.NDArray] - maximum limit
+high: Union[float, npt.NDArray] - maximum limit
+low: Union[float, npt.NDArray] - minimum limit
 
 @@ description
 Constrains a value to not exceed a maximum and minimum value.


### PR DESCRIPTION
I corrected the mix between 'maximum' and 'minimum' in the explanation of the function signature.

I also made another commit to make the description of what the function does clearer, I find the sentence "to not exceed ... a minimum value" a bit weird.

See: https://github.com/py5coding/py5book/pull/108