### PR TITLE
Live coding exit sketch method

### DIFF
--- a/py5_resources/py5_module/py5_tools/live_coding/syncing.py
+++ b/py5_resources/py5_module/py5_tools/live_coding/syncing.py
@@ -128,13 +128,13 @@ class UserFunctionWrapper:
             ):
                 self.f(*args)
         except Exception as e:
-            UserFunctionWrapper.exception_state = True
             self.sketch.no_loop()
 
             self.sketch.println("*" * 80)
             if isinstance(e, Py5ExitSketchException):
                 self.sketch.println(e)
             else:
+                UserFunctionWrapper.exception_state = True
                 py5_bridge.handle_exception(self.sketch.println, *sys.exc_info())
             self.sketch.println("*" * 80)
 


### PR DESCRIPTION
Don't actually exit. Instead, pause and display this message:

```txt
********************************************************************************
Pausing after exit_sketch() call. Resume by updating your code. Exit with the Escape key or by closing the window.
********************************************************************************
```

