### PR TITLE
Fix linux KDE issue

### DIFF
--- a/py5_jar/src/main/java/py5/core/Sketch.java
+++ b/py5_jar/src/main/java/py5/core/Sketch.java
@@ -259,6 +259,11 @@ public class Sketch extends SketchBase {
     if (success && preDrawUpdateRunner != null && !py5RegisteredEvents.contains("post_draw")) {
       preDrawUpdateRunner.interrupt();
     }
+
+    if (frameCount == 1 && platform == LINUX && g.isGL()) {
+      // Linux and OpenGL need to capture pixels after the last draw() call
+      capturePixels();
+    }
   }
 
   protected void preDrawUpdate() {

--- a/py5_jar/src/main/java/py5/core/Sketch.java
+++ b/py5_jar/src/main/java/py5/core/Sketch.java
@@ -261,7 +261,7 @@ public class Sketch extends SketchBase {
     }
 
     if (frameCount == 1 && platform == LINUX && g.isGL()) {
-      // Linux and OpenGL need to capture pixels after the last draw() call
+      // Linux with KDE Plasma window manager and OpenGL need to capture pixels after the last draw() call
       capturePixels();
     }
   }


### PR DESCRIPTION
For some reason with Fedora Linux + KDE Plasma window manager, whatever is drawn in the first `draw()` call doesn't remain in the Sketch window. This code change fixes that 