### PR TITLE
fix: escape Windows paths in STARTUP_CODE string formatting

### DIFF
--- a/py5_resources/py5_module/py5_tools/live_coding/syncing.py
+++ b/py5_resources/py5_module/py5_tools/live_coding/syncing.py
@@ -54,7 +54,7 @@ __cached__ = None
 
 def init_namespace(filename, global_namespace):
     global_namespace.clear()
-    exec(STARTUP_CODE.format(Path(filename).absolute()), global_namespace)
+    exec(STARTUP_CODE.format(Path(filename).absolute().as_posix()), global_namespace)
 
 
 def is_subdirectory(d, f):


### PR DESCRIPTION
When running on Windows systems, the STARTUP_CODE template's __file__ assignment could fail due to unescaped backslashes in the Windows path. This occurs when formatting the path string into STARTUP_CODE, as Windows paths (e.g., "C:\Users\...") contain backslashes that need proper escaping in Python strings.

The fix uses Path.as_posix() to convert Windows backslashes to forward slashes, which Python handles correctly across all operating systems. This ensures the path string is properly escaped when inserted into the STARTUP_CODE template.

Technical details:
- Uses existing pathlib.Path object's as_posix() method
- Converts "C:\path\to\file" to "C:/path/to/file"
- Maintains cross-platform compatibility
- Fixes string formatting issues without changing functionality