### PR TITLE
Remove deprecated license classifier

### DIFF
--- a/py5-resources/py5-module/pyproject.toml
+++ b/py5-resources/py5-module/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
     "Programming Language :: Java",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
https://peps.python.org/pep-0639/#deprecate-license-classifiers