### PR TITLE
Simplify MathMixin.random_choice()

### DIFF
--- a/py5-resources/py5-module/src/py5/mixins/math.py
+++ b/py5-resources/py5-module/src/py5/mixins/math.py
@@ -330,10 +330,10 @@ class MathMixin:
 
     def random_choice(self, seq: Sequence[Any]) -> Any:
         """$class_Sketch_random_choice"""
-        if len(seq):
-            return self._rng.choice(seq)
-        else:
+        if not len(seq):
             return None
+
+        return self._rng.choice(seq)
 
     def random_sample(
         self, seq: Sequence[Any], size: int = 1, replace: bool = True

--- a/py5-resources/py5-module/src/py5/mixins/math.py
+++ b/py5-resources/py5-module/src/py5/mixins/math.py
@@ -331,7 +331,7 @@ class MathMixin:
     def random_choice(self, seq: Sequence[Any]) -> Any:
         """$class_Sketch_random_choice"""
         if len(seq):
-            return seq[self._rng.integers(0, len(seq))]
+            return self._rng.choice(seq)
         else:
             return None
 


### PR DESCRIPTION
Removes redundant Java-style index based approach.

This was the original approach with .random_choice(), but the code move away from it in f8076aa4f3b7fcaaba4b233743d1a516380a5d98 without any explanation.