### PR TITLE
Add type hints for ._instance

### DIFF
--- a/py5-resources/py5-module/src/py5/base.py
+++ b/py5-resources/py5-module/src/py5/base.py
@@ -17,12 +17,22 @@
 #   along with this library. If not, see <https://www.gnu.org/licenses/>.
 #
 # *****************************************************************************
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from py5.sketch import _Sketch
+
+
+__all__ = ("Py5Base",)
+
+
 class Py5Base:
-    def __init__(self, instance):
-        self._instance = instance
+    def __init__(self, instance: "_Sketch"):
+        self._instance: "_Sketch" = instance
 
     def _shutdown(self):
         self._shutdown_complete = True
 
-    def _replace_instance(self, new_instance):
-        self._instance = new_instance
+    def _replace_instance(self, new_instance: "_Sketch"):
+        self._instance: "_Sketch" = new_instance


### PR DESCRIPTION
The goal is to help with IDEs' "jump to source" and similar functions via providing type hint info